### PR TITLE
Improve error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,14 +11,22 @@ const getHtmlFiles = async (directory) => {
   return files.filter((file) => path.extname(file) === '.html')
 }
 
+const inlineSources = async ({ htmlFiles, inputs, constants, utils }) => {
+  try {
+    const inlineSourcePromises = htmlFiles.map((file) =>
+      inlineSource(file, { ...inputs, rootpath: constants.PUBLISH_DIR })
+    )
+    const htmlWithInlinedSources = await Promise.all(inlineSourcePromises)
+    return htmlWithInlinedSources
+  } catch (error) {
+    utils.build.failBuild('Inlining sources failed.', { error })
+  }
+}
+
 module.exports = {
   onPostBuild: async ({ inputs, constants, utils }) => {
-    try {
       const htmlFiles = await getHtmlFiles(constants.PUBLISH_DIR)
-      const inlineSourcePromises = htmlFiles.map((file) =>
-        inlineSource(file, { ...inputs, rootpath: constants.PUBLISH_DIR })
-      )
-      const htmlWithInlinedSources = await Promise.all(inlineSourcePromises)
+      const htmlWithInlinedSources = await inlineSources({ htmlFiles, inputs, constants, utils })
       const overwriteFilePromises = htmlWithInlinedSources.map(
         (content, index) => {
           const filePath = path.join(constants.PUBLISH_DIR, htmlFiles[index])
@@ -30,8 +38,5 @@ module.exports = {
       await Promise.all(overwriteFilePromises)
 
       console.log('Sources successfully inlined!')
-    } catch (error) {
-      utils.build.failBuild('Inlining sources failed.', { error })
-    }
   }
 }


### PR DESCRIPTION
Errors reported by `utils.build.failBuild()` are shown as user errors. This PR limits the `try`/`catch` block to the only lines of code which might throw user errors. Like this, if an error happens outside of those lines of code, this will be properly reported as a plugin bug instead of a user error.